### PR TITLE
Fix file version regex not recognising decimals

### DIFF
--- a/completions/docker-compose.fish
+++ b/completions/docker-compose.fish
@@ -29,8 +29,8 @@ end
 function __fish_docker_compose_file_version --description \
         'Get the version of a docker-compose.yml file.'
     cat (__fish_docker_compose_file_path) \
-        | command grep '^version:\(\s*\)["\']\?[0-9]["\']\?' \
-        | command grep -o '[0-9]'
+        | command grep '^version:\(\s*\)["\']\?[.0-9]*["\']\?' \
+        | command grep -o '[.0-9]*'
 
     if test $status -ne 0
         echo '1'


### PR DESCRIPTION
When parsing docker-compose.yml for the file version, decimal values
are now recognised. File versions such as 2.1 should now be correctly
recognised.

Fixes #9