### PR TITLE
Use native docker-compose command to get services

### DIFF
--- a/completions/docker-compose.fish
+++ b/completions/docker-compose.fish
@@ -39,20 +39,7 @@ end
 
 function __fish_docker_compose_all_services --description \
         'List all services in docker-compose.yml.'
-    set -l path (__fish_docker_compose_file_path)
-    set -l file_version (__fish_docker_compose_file_version)
-    set -l chars 'a-zA-Z0-9_.-'
-
-    switch $file_version
-        case '1'
-            cat $path | command grep '^[a-zA-Z]' | command sed 's/://'
-        case '*'
-            # TODO: currently this only finds services that are indented with
-            # 2 spaces. Make it work with any indentation.
-            cat $path | command sed -n '/^services:/,/^\w/p' \
-                | command grep "^  [$chars]*:" \
-                | command sed "s/[^$chars]//g"
-    end
+  command docker-compose config --services
 end
 
 


### PR DESCRIPTION
As suggested on issue #14 I enhanced the service autocomplete by using docker-compose native way of getting services. 